### PR TITLE
Refactor token generation logic and disable unused methods

### DIFF
--- a/EV-Station.Application/Common/Abstractions/IServices/ITokenService.cs
+++ b/EV-Station.Application/Common/Abstractions/IServices/ITokenService.cs
@@ -6,6 +6,6 @@ namespace EV_Station.Application.Common.Abstractions.IServices
     {
         public string GenerateAccessToken(User user);
         public string GenerateRefreshToken();
-        public string GenerateAndMapRefreshToken(User user);
+        //public string GenerateAndMapRefreshToken(User user);
     }
 }

--- a/EV-Station.Application/Users/CommandHandlers/AuthCommandHandlers/LoginUserHandler.cs
+++ b/EV-Station.Application/Users/CommandHandlers/AuthCommandHandlers/LoginUserHandler.cs
@@ -4,6 +4,7 @@ using EV_Station.Application.Common.Abstractions.IServices;
 using EV_Station.Application.Common.Responses;
 using EV_Station.Application.Users.Commands.AuthCommands;
 using EV_Station.Application.Users.DTOs.Response;
+using EV_Station.Domain.Models;
 using MediatR;
 
 namespace EV_Station.Application.Users.CommandHandlers.AuthCommandHandlers
@@ -42,12 +43,7 @@ namespace EV_Station.Application.Users.CommandHandlers.AuthCommandHandlers
                     return GenericApiResponse<UserTokensReponse>.FailResponse("Password is incorrect");
                 }
 
-                var data = new UserTokensReponse
-                {
-                    User = _mapper.Map<UserResponseDto>(user),
-                    AccessToken = _tokenService.GenerateAccessToken(user),
-                    RefreshToken = _tokenService.GenerateAndMapRefreshToken(user),
-                };
+                var data = await GenerateAndUpdateUserTokensAsync(user, cancellationToken);
 
                 await _uow.SaveChangesAsync(cancellationToken);
                 await _uow.CommitAsync();
@@ -58,6 +54,27 @@ namespace EV_Station.Application.Users.CommandHandlers.AuthCommandHandlers
                 await _uow.RollbackAsync();
                 return GenericApiResponse<UserTokensReponse>.FailResponse("Login user failed");
             }
+        }
+
+        private async Task<UserTokensReponse> GenerateAndUpdateUserTokensAsync(User user, CancellationToken cancellationToken)
+        {
+            var accessToken = _tokenService.GenerateAccessToken(user);
+            var refreshToken = _tokenService.GenerateRefreshToken();
+
+            var data = new UserTokensReponse
+            {
+                User = _mapper.Map<UserResponseDto>(user),
+                AccessToken = accessToken,
+                RefreshToken = refreshToken,
+            };
+
+            user.RefreshToken = refreshToken;
+            user.RefreshTokenExpiryTime = DateTime.UtcNow.AddDays(7);
+
+            _uow.Users.Update(user);
+            await _uow.SaveChangesAsync(cancellationToken);
+
+            return data;
         }
     }
 }

--- a/EV-Station.Infrastructure/Services/TokenService.cs
+++ b/EV-Station.Infrastructure/Services/TokenService.cs
@@ -11,12 +11,10 @@ namespace EV_Station.Infrastructure.Services
     public class TokenService : ITokenService
     {
         private readonly IConfiguration _configuration;
-        private readonly IUnitOfWork _uow;
 
         public TokenService(IConfiguration configuration, IUnitOfWork uow)
         {
             _configuration = configuration;
-            _uow = uow;
         }
 
         public string GenerateAccessToken(User user)
@@ -37,16 +35,16 @@ namespace EV_Station.Infrastructure.Services
             return new JwtSecurityTokenHandler().WriteToken(new JwtSecurityTokenHandler().CreateToken(tokenDescriptor));
         }
 
-        public string GenerateAndMapRefreshToken(User user)
-        {
-            var userRepository = _uow.Users;
+        //public string GenerateAndMapRefreshToken(User user)
+        //{
+        //    var userRepository = _uow.Users;
 
-            var refreshToken = GenerateRefreshToken();
-            user.RefreshToken = refreshToken;
-            user.RefreshTokenExpiryTime = DateTime.UtcNow.AddDays(7);
-            userRepository.Update(user);
-            return refreshToken;
-        }
+        //    var refreshToken = GenerateRefreshToken();
+        //    user.RefreshToken = refreshToken;
+        //    user.RefreshTokenExpiryTime = DateTime.UtcNow.AddDays(7);
+        //    userRepository.Update(user);
+        //    return refreshToken;
+        //}
 
         public string GenerateRefreshToken()
         {


### PR DESCRIPTION
Comment out `GenerateAndMapRefreshToken` in `ITokenService` and `TokenService`. Refactor token generation in `LoginUserHandler` to a new asynchronous method, `GenerateAndUpdateUserTokensAsync`, which handles both access and refresh tokens, updates the user entity, and saves changes to the database.