### PR TITLE
Add refresh token endpoint and related logic

### DIFF
--- a/EV-Station.Api/Endpoints/Auth/AuthV1Endpoints.cs
+++ b/EV-Station.Api/Endpoints/Auth/AuthV1Endpoints.cs
@@ -1,4 +1,5 @@
-﻿namespace EV_Station.Api.Endpoints.Auth
+﻿
+namespace EV_Station.Api.Endpoints.Auth
 {
     public class AuthV1Endpoints : IEndpointDefinition
     {
@@ -18,6 +19,17 @@
             v1.MapPost("google-login", GoogleLoginAsync)
                 .WithName("GoogleLoginUser")
                 .AddEndpointFilter<GoogleLoginValidationFilter>();
+
+            v1.MapPost("refresh-token", RefreshTokenAsync)
+                .WithName("RefreshToken");
+
+        }
+
+        private async Task<Results<Ok<GenericApiResponse<UserTokensReponse>>, NotFound>> RefreshTokenAsync([FromBody] UserRefreshTokenDto request, IMediator mediator)
+        {
+            var refreshTokenQuery = new RefreshTokenUser(request);
+            var result = await mediator.Send(refreshTokenQuery);
+            return result is not null ? TypedResults.Ok(result) : TypedResults.NotFound();
         }
 
         private async Task<Results<Ok<GenericApiResponse<UserTokensReponse>>, NotFound>> GoogleLoginAsync(GoogleLoginDto dto, IMediator mediator)

--- a/EV-Station.Application/Common/Abstractions/IServices/ITokenService.cs
+++ b/EV-Station.Application/Common/Abstractions/IServices/ITokenService.cs
@@ -1,4 +1,5 @@
-﻿using EV_Station.Domain.Models;
+﻿using EV_Station.Application.Users.DTOs.Response;
+using EV_Station.Domain.Models;
 
 namespace EV_Station.Application.Common.Abstractions.IServices
 {
@@ -6,6 +7,5 @@ namespace EV_Station.Application.Common.Abstractions.IServices
     {
         public string GenerateAccessToken(User user);
         public string GenerateRefreshToken();
-        //public string GenerateAndMapRefreshToken(User user);
     }
 }

--- a/EV-Station.Application/Users/DTOs/Requests/UserRefreshTokenDto.cs
+++ b/EV-Station.Application/Users/DTOs/Requests/UserRefreshTokenDto.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EV_Station.Application.Users.DTOs.Requests
+{
+    public record UserRefreshTokenDto
+    (
+        Guid userId,
+        string refreshToken
+    );
+}

--- a/EV-Station.Application/Users/Querries/RefreshTokenUser.cs
+++ b/EV-Station.Application/Users/Querries/RefreshTokenUser.cs
@@ -1,0 +1,11 @@
+﻿using EV_Station.Application.Common.Responses;
+using EV_Station.Application.Users.DTOs.Requests;
+using EV_Station.Application.Users.DTOs.Response;
+using MediatR;
+
+namespace EV_Station.Application.Users.Querries
+{
+
+    public record RefreshTokenUser(UserRefreshTokenDto dto) : IRequest<GenericApiResponse<UserTokensReponse>>;
+
+}

--- a/EV-Station.Application/Users/QuerryHandlers/RefreshTokenUserHandler.cs
+++ b/EV-Station.Application/Users/QuerryHandlers/RefreshTokenUserHandler.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using AutoMapper;
+using EV_Station.Application.Common.Abstractions.IRepositories.IBaseRepositories;
+using EV_Station.Application.Common.Abstractions.IServices;
+using EV_Station.Application.Common.Responses;
+using EV_Station.Application.Users.DTOs.Response;
+using EV_Station.Application.Users.Querries;
+using MediatR;
+
+namespace EV_Station.Application.Users.QuerryHandlers
+{
+    public class RefreshTokenUserHandler : IRequestHandler<RefreshTokenUser, GenericApiResponse<UserTokensReponse>>
+    {
+        private readonly IUnitOfWork _uow;
+        private readonly IMapper _mapper;
+        private readonly ITokenService _tokenService;
+
+        public RefreshTokenUserHandler(IUnitOfWork uow, IMapper mapper, ITokenService tokenService)
+        {
+            _uow = uow;
+            _mapper = mapper;
+            _tokenService = tokenService;
+        }
+
+        public async Task<GenericApiResponse<UserTokensReponse>> Handle(RefreshTokenUser request, CancellationToken cancellationToken)
+        {
+            var userRepository = _uow.Users;
+            var user = await userRepository.GetByIdAsync(request.dto.userId, u => u.Role);
+
+            if (user == null) {
+                return GenericApiResponse<UserTokensReponse>.FailResponse("User not found");
+            }
+            if(user.RefreshToken != request.dto.refreshToken)
+            {
+                return GenericApiResponse<UserTokensReponse>.FailResponse("Invalid refresh token");
+            }
+            if (user.RefreshTokenExpiryTime < DateTime.UtcNow)
+            {
+                return GenericApiResponse<UserTokensReponse>.FailResponse("Refresh token has expired");
+            }
+
+            var newAccessToken = _tokenService.GenerateAccessToken(user);
+
+            var response = new UserTokensReponse
+            {
+                User = _mapper.Map<UserResponseDto>(user),
+                AccessToken = newAccessToken,
+                RefreshToken = request.dto.refreshToken
+            };
+
+            return GenericApiResponse<UserTokensReponse>.SuccessResponse(response, "Token refreshed successfully");
+        }
+    }
+}

--- a/EV-Station.Infrastructure/Services/TokenService.cs
+++ b/EV-Station.Infrastructure/Services/TokenService.cs
@@ -1,5 +1,6 @@
 ﻿using EV_Station.Application.Common.Abstractions.IRepositories.IBaseRepositories;
 using EV_Station.Application.Common.Abstractions.IServices;
+using EV_Station.Application.Users.DTOs.Response;
 using EV_Station.Domain.Models;
 using Microsoft.Extensions.Configuration;
 using Microsoft.IdentityModel.Tokens;
@@ -34,17 +35,6 @@ namespace EV_Station.Infrastructure.Services
 
             return new JwtSecurityTokenHandler().WriteToken(new JwtSecurityTokenHandler().CreateToken(tokenDescriptor));
         }
-
-        //public string GenerateAndMapRefreshToken(User user)
-        //{
-        //    var userRepository = _uow.Users;
-
-        //    var refreshToken = GenerateRefreshToken();
-        //    user.RefreshToken = refreshToken;
-        //    user.RefreshTokenExpiryTime = DateTime.UtcNow.AddDays(7);
-        //    userRepository.Update(user);
-        //    return refreshToken;
-        //}
 
         public string GenerateRefreshToken()
         {


### PR DESCRIPTION
Introduces a new endpoint for refreshing user tokens in `AuthV1Endpoints.cs` with the `RefreshTokenAsync` method. Adds `UserRefreshTokenDto` for data transfer and implements the `RefreshTokenUser` request and `RefreshTokenUserHandler` for processing. Removes the commented-out `GenerateAndMapRefreshToken` method in `ITokenService.cs` to simplify token generation logic. Updates `TokenService.cs` with necessary using directives. These changes enhance the authentication mechanism for improved user experience.