### PR TITLE
Add identity card creation and scanning functionality

### DIFF
--- a/EV-Station.Api/Endpoints/IdentityCards/IdentityCardV1Endpoints.cs
+++ b/EV-Station.Api/Endpoints/IdentityCards/IdentityCardV1Endpoints.cs
@@ -11,9 +11,23 @@ namespace EV_Station.Api.Endpoints.IdentityCards
         {
             var v1 = application.MapGroup("api/v{version:apiVersion}/identity-cards").WithApiVersionSet().HasApiVersion(1, 0);
 
-            v1.MapPost("/scan", ScanIdentityCard);
+            v1.MapPost("/scan", ScanIdentityCard)
+                .WithName("ScanIdentityCard")
+                .RequireAuthorization();
+
+            v1.MapPost("/create", CreateIdentityCard)
+                .WithName("CreateIdentityCard")
+                .RequireAuthorization();
         }
 
+        private async Task<Results<Ok<GenericApiResponse<IdentityCardResponse>>, NotFound>> CreateIdentityCard(ICurrentUserService currentUserService, IdentityCardRequest request, IMediator mediator)
+        {
+            var userId = currentUserService.UserId;
+            var createIdentityCardCommand = new CreateIdentityCard(userId, request);
+            var result = await mediator.Send(createIdentityCardCommand);
+            return result is not null ? TypedResults.Ok(result) : TypedResults.NotFound();
+
+        }
 
         private async Task<Results<Ok<GenericApiResponse<IdentityCardScanResponse>>, NotFound>> ScanIdentityCard(IdentityCardScanRequest request, IMediator mediator)
         {

--- a/EV-Station.Api/Extensions/ApplicationServiceExtensions.cs
+++ b/EV-Station.Api/Extensions/ApplicationServiceExtensions.cs
@@ -13,6 +13,7 @@ namespace EV_Station.Api.Extensions
             AddApiVersioning(builder);
             AddCors(builder);
             AddAuthentication(builder);
+            builder.Services.AddHttpContextAccessor();
             builder.Services.AddAuthorization();
 
             builder.Services.AddMediatR(typeof(RegisterUser).Assembly);

--- a/EV-Station.Application/Common/Abstractions/IRepositories/IBaseRepositories/IUnitOfWork.cs
+++ b/EV-Station.Application/Common/Abstractions/IRepositories/IBaseRepositories/IUnitOfWork.cs
@@ -7,6 +7,7 @@
         IProviderRepository Providers { get; }
 
 
+
         IGenericRepository<T> Repository<T>() where T : class;
         Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
         Task BeginTransactionAsync();

--- a/EV-Station.Application/Common/Mappings/IdentityCardProfile.cs
+++ b/EV-Station.Application/Common/Mappings/IdentityCardProfile.cs
@@ -1,0 +1,13 @@
+﻿using AutoMapper;
+
+namespace EV_Station.Application.Common.Mappings
+{
+    public class IdentityCardProfile : Profile
+    {
+        public IdentityCardProfile()
+        {
+
+
+        }
+    }
+}

--- a/EV-Station.Application/EV-Station.Application.csproj
+++ b/EV-Station.Application/EV-Station.Application.csproj
@@ -26,8 +26,6 @@
     <Folder Include="DriverLisences\DTOs\Requests\" />
     <Folder Include="DriverLisences\QueryHandlers\" />
     <Folder Include="DriverLisences\Queries\" />
-    <Folder Include="IdentityCards\CommandHandlers\" />
-    <Folder Include="IdentityCards\Commands\" />
   </ItemGroup>
 
 </Project>

--- a/EV-Station.Application/IdentityCards/CommandHandlers/CreateIdentityCardHandler.cs
+++ b/EV-Station.Application/IdentityCards/CommandHandlers/CreateIdentityCardHandler.cs
@@ -1,0 +1,62 @@
+﻿using AutoMapper;
+using EV_Station.Application.Common.Abstractions.IRepositories.IBaseRepositories;
+using EV_Station.Application.Common.Responses;
+using EV_Station.Application.IdentityCards.Commands;
+using EV_Station.Application.IdentityCards.DTOs.Responses;
+using EV_Station.Domain.Models;
+using MediatR;
+
+namespace EV_Station.Application.IdentityCards.CommandHandlers
+{
+    public class CreateIdentityCardHandler : IRequestHandler<CreateIdentityCard, GenericApiResponse<IdentityCardResponse>>
+    {
+        private readonly IUnitOfWork _uow;
+        private readonly IMapper _mapper;
+
+        public CreateIdentityCardHandler(IUnitOfWork uow, IMapper mapper)
+        {
+            _uow = uow;
+            _mapper = mapper;
+        }
+
+        public async Task<GenericApiResponse<IdentityCardResponse>> Handle(CreateIdentityCard request, CancellationToken cancellationToken)
+        {
+            await _uow.BeginTransactionAsync();
+            try
+            {
+                var identityCardRepository = _uow.Repository<IdentityCard>();
+                var userRepository = _uow.Users;
+
+                var userHasIdentityCard = (await identityCardRepository.GetAllAsync(ic => ic.UserId == request.userId)).Any();
+                if (userHasIdentityCard)
+                {
+                    return GenericApiResponse<IdentityCardResponse>.FailResponse("User already has an identity card.");
+                }
+
+                var existingIdentityCard = (await identityCardRepository.GetAllAsync(ic => ic.UserId == request.userId && ic.CardNumber == request.dto.CardNumber))
+                    .FirstOrDefault();
+                if (existingIdentityCard != null)
+                {
+                    return GenericApiResponse<IdentityCardResponse>.FailResponse("User already owns this card number.");
+                }
+
+
+
+                var newIdentityCard = _mapper.Map<IdentityCard>(request.dto);
+                newIdentityCard.UserId = request.userId;
+                await identityCardRepository.AddAsync(newIdentityCard);
+
+                await _uow.SaveChangesAsync(cancellationToken);
+                await _uow.CommitAsync();
+                var response = _mapper.Map<IdentityCardResponse>(newIdentityCard);
+                return GenericApiResponse<IdentityCardResponse>.SuccessResponse(response);
+            }
+            catch
+            {
+                await _uow.RollbackAsync();
+                return GenericApiResponse<IdentityCardResponse>.FailResponse("An error occurred while creating the identity card.");
+            }
+
+        }
+    }
+}

--- a/EV-Station.Application/IdentityCards/Commands/CreateIdentityCard.cs
+++ b/EV-Station.Application/IdentityCards/Commands/CreateIdentityCard.cs
@@ -1,0 +1,9 @@
+﻿using EV_Station.Application.Common.Responses;
+using EV_Station.Application.IdentityCards.DTOs.Requests;
+using EV_Station.Application.IdentityCards.DTOs.Responses;
+using MediatR;
+
+namespace EV_Station.Application.IdentityCards.Commands
+{
+    public record CreateIdentityCard(Guid userId, IdentityCardRequest dto) : IRequest<GenericApiResponse<IdentityCardResponse>>;
+}

--- a/EV-Station.Application/IdentityCards/DTOs/Requests/IdentityCardRequest.cs
+++ b/EV-Station.Application/IdentityCards/DTOs/Requests/IdentityCardRequest.cs
@@ -11,5 +11,7 @@
         public string PlaceOfResidence { get; set; } = string.Empty;
         public DateOnly? CreateDate { get; set; }
         public DateOnly? DayOfExpiry { get; set; }
+
+
     }
 }


### PR DESCRIPTION
Updated `IdentityCardV1Endpoints.cs` to include new endpoints for creating and scanning identity cards, both requiring authorization. Added a private method `CreateIdentityCard` for handling creation responses.

Introduced `CreateIdentityCardHandler.cs` to manage identity card creation logic and transactions. Extended `IUnitOfWork.cs` with a generic repository method and transaction management tasks.

Created `IdentityCardProfile.cs` for AutoMapper configurations. Added `CreateIdentityCard` record to encapsulate creation data. Updated `IdentityCardRequest.cs` with additional properties.

Modified `ApplicationServiceExtensions.cs` to include `AddHttpContextAccessor` for accessing the current HTTP context. Removed identity card-related folders from `EV-Station.Application.csproj`.