### PR TITLE
Refactor identity card retrieval and authorization roles

### DIFF
--- a/EV-Station.Api/Endpoints/IdentityCards/IdentityCardV1Endpoints.cs
+++ b/EV-Station.Api/Endpoints/IdentityCards/IdentityCardV1Endpoints.cs
@@ -11,7 +11,7 @@ namespace EV_Station.Api.Endpoints.IdentityCards
                .WithName("CreateIdentityCard")
                .RequireAuthorization();
 
-            v1.MapGet("/{cardNumber}", GetIdentityCardById)
+            v1.MapGet("/{id: Guid}", GetIdentityCardById)
                 .WithName("GetIdentityCardById")
                 .RequireAuthorization();
 
@@ -26,9 +26,9 @@ namespace EV_Station.Api.Endpoints.IdentityCards
                 .DisableAntiforgery();
         }
 
-        private async Task<Results<Ok<GenericApiResponse<IdentityCardResponse>>, NotFound>> GetIdentityCardById(string cardNumber, IMediator mediator)
+        private async Task<Results<Ok<GenericApiResponse<IdentityCardResponse>>, NotFound>> GetIdentityCardById(Guid id, IMediator mediator)
         {
-            var getMyIdentityCardQuery = new GetIdentityCardById(cardNumber);
+            var getMyIdentityCardQuery = new GetIdentityCardById(id);
             var result = await mediator.Send(getMyIdentityCardQuery);
             return result is not null ? TypedResults.Ok(result) : TypedResults.NotFound();
         }

--- a/EV-Station.Api/Endpoints/Users/UserV1Endpoints.cs
+++ b/EV-Station.Api/Endpoints/Users/UserV1Endpoints.cs
@@ -12,7 +12,7 @@
 
             v1.MapGet("/{id:guid}", GetUserByIdAsync)
                 .WithName("GetUserById")
-                .RequireAuthorization(new AuthorizeAttribute { Roles = "Staff, Admin" });
+                .RequireAuthorization(new AuthorizeAttribute { Roles = "Staff, Admin, Renter" });
 
             v1.MapPost("", CreateUserAsync)
                 .WithName("CreateUser")

--- a/EV-Station.Application/IdentityCards/DTOs/Responses/IdentityCardResponse.cs
+++ b/EV-Station.Application/IdentityCards/DTOs/Responses/IdentityCardResponse.cs
@@ -4,7 +4,6 @@ namespace EV_Station.Application.IdentityCards.DTOs.Responses
 {
     public class IdentityCardResponse
     {
-        public long Id { get; set; }
         public string CardNumber { get; set; } = default!;
         public string FullName { get; set; } = default!;
         public DateOnly DateOfBirth { get; set; }
@@ -15,5 +14,6 @@ namespace EV_Station.Application.IdentityCards.DTOs.Responses
         public string? FrontImageUrl { get; set; }
         public string? BackImageUrl { get; set; }
         public VerificationStatus Status { get; set; }
+        public string UserId { get; set; } = default!;
     }
 }

--- a/EV-Station.Application/IdentityCards/Queries/GetIdentityCardById.cs
+++ b/EV-Station.Application/IdentityCards/Queries/GetIdentityCardById.cs
@@ -4,5 +4,5 @@ using MediatR;
 
 namespace EV_Station.Application.IdentityCards.Queries
 {
-    public record GetIdentityCardById(string cardNumber) : IRequest<GenericApiResponse<IdentityCardResponse>>;
+    public record GetIdentityCardById(Guid id) : IRequest<GenericApiResponse<IdentityCardResponse>>;
 }

--- a/EV-Station.Application/IdentityCards/QueryHandlers/GetIdentityCardByIdHandler.cs
+++ b/EV-Station.Application/IdentityCards/QueryHandlers/GetIdentityCardByIdHandler.cs
@@ -19,7 +19,8 @@ namespace EV_Station.Application.IdentityCards.QueryHandlers
 
         public async Task<GenericApiResponse<IdentityCardResponse>> Handle(GetIdentityCardById request, CancellationToken cancellationToken)
         {
-            var identityCard = await _uow.IdentityCards.GetIdentityCardByNumber(request.cardNumber);
+            var identityCards = await _uow.IdentityCards.GetAllAsync();
+            var identityCard = identityCards.FirstOrDefault(ic => ic.UserId == request.id);
             if (identityCard is null)
             {
                 return GenericApiResponse<IdentityCardResponse>.FailResponse("Identity card not found");


### PR DESCRIPTION
Updated the `GetIdentityCardById` method to accept a `Guid` instead of a `string` and modified the corresponding route. Expanded authorization roles for `GetUserById` to include "Renter". Added a `UserId` property to the `IdentityCardResponse` class. Adjusted the `GetIdentityCardById` record and handler logic to improve user-specific data retrieval.